### PR TITLE
test: expand API and pagination coverage

### DIFF
--- a/app/(app)/user/[profile]/page.tsx
+++ b/app/(app)/user/[profile]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { auth } from "@/auth";
 import { SessionProvider } from "next-auth/react";
 import { prisma } from '@/prisma';
+import { normalizePage, normalizeQuery } from '@/lib/pagination';
 
 export default async function Profile(props: {
   params: Promise<{ profile: string }>;
@@ -19,9 +20,8 @@ export default async function Profile(props: {
 }) {
   const session = await auth();
   const search = await props.searchParams;
-  const query = (search?.query || '').slice(0, 200);
-  const requestedPage = Number(search?.page);
-  const page = Number.isSafeInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1;
+  const query = normalizeQuery(search?.query);
+  const page = normalizePage(search?.page);
 
   const { profile } = await props.params;
   const username = profile;

--- a/app/(non)/api/draw/route.test.ts
+++ b/app/(non)/api/draw/route.test.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  fetchPublicHtml: vi.fn(),
+}));
+
+vi.mock('@/auth', () => ({ auth: mocks.auth }));
+vi.mock('@/lib/safe-url', () => ({ fetchPublicHtml: mocks.fetchPublicHtml }));
+
+import { GET } from './route';
+
+function request(query = '') {
+  return new NextRequest(`http://localhost/api/draw${query ? `?q=${encodeURIComponent(query)}` : ''}`);
+}
+
+describe('/api/draw', () => {
+  beforeEach(() => {
+    mocks.auth.mockResolvedValue({ user: { id: 'user-1' } });
+    mocks.fetchPublicHtml.mockResolvedValue({
+      html: '<html><head><title>Example</title><meta property="og:description" content="Description"><meta property="og:image" content="https://example.com/image.png"></head></html>',
+      url: new URL('https://example.com/page'),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requires authentication before fetching a remote URL', async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    const response = await GET(request('https://example.com'));
+
+    expect(response.status).toBe(401);
+    expect(mocks.fetchPublicHtml).not.toHaveBeenCalled();
+  });
+
+  it('requires a URL query', async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(400);
+    expect(mocks.fetchPublicHtml).not.toHaveBeenCalled();
+  });
+
+  it('extracts bookmark metadata from HTML', async () => {
+    const response = await GET(request('https://example.com/page'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      title: 'Example',
+      description: 'Description',
+      image: 'https://example.com/image.png',
+    });
+  });
+
+  it('does not expose internal fetch errors', async () => {
+    mocks.fetchPublicHtml.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.1:5432'));
+
+    const response = await GET(request('https://example.com'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unable to fetch metadata for that URL.',
+    });
+  });
+
+  it('uses YouTube metadata as a fallback without exposing the API key', async () => {
+    const previousToken = process.env.GOOGLE_TOKEN;
+    process.env.GOOGLE_TOKEN = 'server-secret';
+    mocks.fetchPublicHtml.mockResolvedValue({
+      html: '<html><head></head></html>',
+      url: new URL('https://youtu.be/video-id'),
+    });
+    const youtubeFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      items: [{ snippet: { title: 'Video', description: 'Video description' } }],
+    }), { headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', youtubeFetch);
+
+    try {
+      const response = await GET(request('https://youtu.be/video-id'));
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({ title: 'Video' });
+      expect(youtubeFetch).toHaveBeenCalledWith(expect.stringContaining('key=server-secret'));
+    } finally {
+      if (previousToken === undefined) delete process.env.GOOGLE_TOKEN;
+      else process.env.GOOGLE_TOKEN = previousToken;
+    }
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import KeepWrap from "@/components/app/keep-wrap";
 
 import { auth } from "@/auth";
 import { SessionProvider } from "next-auth/react";
+import { normalizePage, normalizeQuery } from '@/lib/pagination';
 // import { PrismaClient } from '@/prisma/client';
 // const prisma = new PrismaClient();
 
@@ -18,9 +19,8 @@ export default async function Home(props: {
 }) {
   const session = await auth();
   const search = await props.searchParams;
-  const query = (search?.query || '').slice(0, 200);
-  const requestedPage = Number(search?.page);
-  const page = Number.isSafeInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1;
+  const query = normalizeQuery(search?.query);
+  const page = normalizePage(search?.page);
 
   return (
     <>

--- a/components/app/keep-pagination.tsx
+++ b/components/app/keep-pagination.tsx
@@ -17,6 +17,7 @@ import {
 
 import { use } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { getPaginationRange } from '@/lib/pagination';
 
 export default function KeepPagination({
   totalItems,
@@ -33,40 +34,9 @@ export default function KeepPagination({
   const totalCount = use(totalItems);
   const totalPages = Math.ceil(totalCount / itemsCount);
 
-  const pageGroup = pagesCount * 2 + 1;
-
-  const startPage = totalPages <= pageGroup
-    ? 1
-    : (
-        currentPage - pagesCount <= 0
-          ? 1
-          : (
-              (currentPage - pagesCount) - (
-                currentPage + pagesCount <= totalPages
-                  ? 0
-                  : currentPage + pagesCount - totalPages
-              )
-            )
-      );
-
-  const endPage = totalPages <= pageGroup
-    ? totalPages
-    : (
-        currentPage + pagesCount > totalPages
-          ? totalPages
-          : (
-              (currentPage + pagesCount) + (
-                currentPage - pagesCount > 0
-                  ? 0
-                  : pagesCount - currentPage + 1
-              )
-            )
-      );
-
-  const pages = [];
-  for ( let i = startPage; i <= endPage; i++ ) {
-    pages.push(i);
-  }
+  const pages = getPaginationRange(currentPage, totalPages, pagesCount);
+  const startPage = pages[0] ?? 1;
+  const endPage = pages.at(-1) ?? 0;
 
   const createPageURL = (pageNumber: number | string) => {
     const params = new URLSearchParams(searchParams);

--- a/lib/pagination.test.ts
+++ b/lib/pagination.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getPaginationRange, normalizePage, normalizeQuery } from './pagination';
+
+describe('normalizePage', () => {
+  it.each([undefined, null, '', '0', '-1', '1.5', 'NaN', 'Infinity'])('normalizes %s to page one', (value) => {
+    expect(normalizePage(value)).toBe(1);
+  });
+
+  it('keeps positive safe integers', () => {
+    expect(normalizePage('42')).toBe(42);
+  });
+});
+
+describe('normalizeQuery', () => {
+  it('handles missing values and limits query length', () => {
+    expect(normalizeQuery()).toBe('');
+    expect(normalizeQuery('abcdef', 3)).toBe('abc');
+  });
+});
+
+describe('getPaginationRange', () => {
+  it.each([
+    { current: 1, total: 0, expected: [] },
+    { current: 1, total: 3, expected: [1, 2, 3] },
+    { current: 1, total: 10, expected: [1, 2, 3, 4, 5] },
+    { current: 5, total: 10, expected: [3, 4, 5, 6, 7] },
+    { current: 10, total: 10, expected: [6, 7, 8, 9, 10] },
+    { current: 99, total: 10, expected: [6, 7, 8, 9, 10] },
+  ])('builds the range around page $current of $total', ({ current, total, expected }) => {
+    expect(getPaginationRange(current, total)).toEqual(expected);
+  });
+});

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,21 @@
+export function normalizePage(value?: string | null) {
+  const page = Number(value);
+  return Number.isSafeInteger(page) && page > 0 ? page : 1;
+}
+
+export function normalizeQuery(value?: string | null, maxLength = 200) {
+  return (value ?? '').slice(0, maxLength);
+}
+
+export function getPaginationRange(currentPage: number, totalPages: number, pagesAround = 2) {
+  if (totalPages <= 0) return [];
+
+  const safeCurrentPage = Math.min(Math.max(Math.trunc(currentPage), 1), totalPages);
+  const pageGroup = pagesAround * 2 + 1;
+  const startPage = totalPages <= pageGroup
+    ? 1
+    : Math.max(1, Math.min(safeCurrentPage - pagesAround, totalPages - pageGroup + 1));
+  const endPage = Math.min(totalPages, startPage + pageGroup - 1);
+
+  return Array.from({ length: endPage - startPage + 1 }, (_, index) => startPage + index);
+}


### PR DESCRIPTION
## Summary
- add metadata extraction API tests, including authentication and sanitized failures
- add page/query normalization and pagination range tests
- reuse tested pagination helpers in page and pagination components
- expand the suite to 51 passing tests across six files

## Verification
- npm test
- npm run lint (3 existing React Compiler compatibility warnings)
- npx tsc --noEmit
- npm run build